### PR TITLE
Get actual max vehicle count from VehicleManager

### DIFF
--- a/ImprovedPublicTransportMod.cs
+++ b/ImprovedPublicTransportMod.cs
@@ -75,18 +75,8 @@ namespace ImprovedPublicTransport2
 
                     CachedNodeData.Init();
 
-                    int maxVehicleCount;
-                    if (Utils.IsModActive(1764208250)) // More Vehicles
-                    {
-                        Debug.LogWarning(
-                            $"{ShortModName}: More Vehicles is enabled, applying compatibility workaround");
-                        maxVehicleCount = ushort.MaxValue + 1;
-                    }
-                    else
-                    {
-                        Debug.Log($"{ShortModName}: More Vehicles is not enabled");
-                        maxVehicleCount = VehicleManager.MAX_VEHICLE_COUNT;
-                    }
+                    int maxVehicleCount = VehicleManager.instance.m_vehicles.m_buffer.Length;
+                    Debug.LogWarning($"{ShortModName}: MaxVehicleCout is {maxVehicleCount}");
 
                     CachedVehicleData.Init(maxVehicleCount);
 


### PR DESCRIPTION
I would be preferable to get the actual value of the vehicle array from the VehicleManager, instead of guessing its length.
See also in TMPE's code: https://github.com/CitiesSkylinesMods/TMPE/blob/bd2717cd6e4c40e3be213f9bbdd61715505b7fdf/TLM/TLM/Traffic/Impl/SegmentEnd.cs#L108

Point being, that I'm currently playing around with this value in another mod, but IPT2 only has these hard coded values.